### PR TITLE
Avoid unnecessary restore_file calls and option to resume at specific path

### DIFF
--- a/restore.py
+++ b/restore.py
@@ -2,8 +2,8 @@
 import sys, os, dropbox, time
 from datetime import datetime
 
-APP_KEY = 'hacwza866qep9o6'   # INSERT APP_KEY HERE
-APP_SECRET = 'kgipko61g58n6uc'     # INSERT APP_SECRET HERE
+APP_KEY = ''   # INSERT APP_KEY HERE
+APP_SECRET = ''     # INSERT APP_SECRET HERE
 DELAY = 0.2 # delay between each file (try to stay under API rate limits)
 
 HELP_MESSAGE = \


### PR DESCRIPTION
I made two patches:

- the first checks whether the file is already at the same revision (or both revisions are "deleted") and avoids the client.restore() call in that case in order to speed up the script
- the second allows to optionally specify a path to resume at: I often encounter the dropbox server to bail out with [500] u'Internal Server Error' and it's really helpful to resume there.

Hope you find it useful!
